### PR TITLE
Fix Firebase migration regressions and TypeScript build errors

### DIFF
--- a/app/create/community.tsx
+++ b/app/create/community.tsx
@@ -66,11 +66,7 @@ async function ensureUniqueSlug(base: string) {
       ),
     );
 
-    if (error) {
-      // if slug column doesn’t exist, we just return attempt (fallback)
-      return attempt;
-    }
-    if (!data) return attempt;
+    if (snapU.empty) return attempt;
   }
 
   return `${slug}-${Date.now().toString().slice(-5)}`;

--- a/app/create/media.tsx
+++ b/app/create/media.tsx
@@ -147,8 +147,6 @@ export default function CreateMediaScreen() {
         const fileRef = storageRef(storage, path);
         await uploadBytes(fileRef, arrayBuffer, { contentType: mime });
 
-        if (uploadError) throw uploadError;
-
         const publicUrl = await getDownloadURL(fileRef);
         uploadedUrls.push(publicUrl);
       } catch (err) {
@@ -199,7 +197,6 @@ export default function CreateMediaScreen() {
         updated_at: nowIso,
       });
 
-      if (error) throw error;
 
       Alert.alert("Success", "Media shared successfully!", [
         { text: "OK", onPress: () => router.back() },

--- a/app/create/poll.tsx
+++ b/app/create/poll.tsx
@@ -147,8 +147,6 @@ export default function CreateMediaScreen() {
         const fileRef = storageRef(storage, path);
         await uploadBytes(fileRef, arrayBuffer, { contentType: mime });
 
-        if (uploadError) throw uploadError;
-
         const publicUrl = await getDownloadURL(fileRef);
         uploadedUrls.push(publicUrl);
       } catch (err) {
@@ -199,7 +197,6 @@ export default function CreateMediaScreen() {
         updated_at: nowIso,
       });
 
-      if (error) throw error;
 
       Alert.alert("Success", "Media shared successfully!", [
         { text: "OK", onPress: () => router.back() },

--- a/app/create/post.tsx
+++ b/app/create/post.tsx
@@ -174,9 +174,7 @@ export default function CreatePostScreen() {
   };
 
   /**
-   * Upload media to Supabase Storage and return public URL string[]
-   * Bucket: post-media
-   * Path: media/<userId>/<timestamp-random>.<ext>
+   * Upload media to Firebase Storage and return public URL string[].
    */
   const uploadPostMedia = async (): Promise<string[]> => {
     if (!user) throw new Error("Not logged in");
@@ -198,11 +196,6 @@ export default function CreatePostScreen() {
       const storage = getStorage();
       const fileRef = storageRef(storage, path);
       await uploadBytes(fileRef, arrayBuffer, { contentType: mime });
-
-      if (uploadError) {
-        console.error("Storage upload error:", uploadError);
-        throw new Error("Upload failed. Check storage bucket policy.");
-      }
 
       const publicUrl = await getDownloadURL(fileRef);
       uploadedUrls.push(publicUrl);
@@ -264,8 +257,6 @@ export default function CreatePostScreen() {
         comment_count: 0,
         share_count: 0,
       });
-
-      if (error) throw error;
 
       Alert.alert("Success", "Your post has been created!", [
         { text: "OK", onPress: () => router.back() },

--- a/app/create/story.tsx
+++ b/app/create/story.tsx
@@ -1,5 +1,5 @@
 // app/create/story.tsx - COMPLETED (Private bucket ready + Android content:// safe)
-import { createStory, uploadStoryMedia } from "@/lib/queries/stories";
+import { createStory, uploadStoryMedia } from "@/lib/firestore/stories";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,7 +5,7 @@ import { Redirect } from "expo-router";
 import { ActivityIndicator, View } from "react-native";
 
 export default function Index() {
-  const { session, isLoading, isUserSettingsLoading, hasCompletedOnboarding } =
+  const { user, isLoading, isUserSettingsLoading, hasCompletedOnboarding } =
     useAuth();
 
   // Wait for session hydration
@@ -18,7 +18,7 @@ export default function Index() {
   }
 
   // Not signed in -> auth flow
-  if (!session?.user) return <Redirect href="/(auth)/login" />;
+  if (!user) return <Redirect href="/(auth)/login" />;
 
   // Signed in -> WAIT for settings before deciding onboarding
   if (isUserSettingsLoading) {

--- a/app/settings/linked-accounts.tsx
+++ b/app/settings/linked-accounts.tsx
@@ -73,7 +73,7 @@ export default function LinkedAccountsScreen() {
     {
       id: "1",
       provider: "google",
-      email: user?.email,
+      email: user?.email ?? undefined,
       connectedAt: new Date().toISOString(),
     },
   ]);

--- a/components/navigation/CurvedTabBar.tsx
+++ b/components/navigation/CurvedTabBar.tsx
@@ -224,8 +224,7 @@ export default function CurvedTabBar({
             badge !== undefined &&
             badge !== null &&
             badge !== 0 &&
-            badge !== "" &&
-            badge !== false;
+            badge !== "";
 
           return (
             <TouchableOpacity

--- a/components/post/ReactionButtons.tsx
+++ b/components/post/ReactionButtons.tsx
@@ -229,7 +229,7 @@ const styles = StyleSheet.create({
     borderRadius: 3,
   },
   overlay: {
-    position: 'fixed',
+    position: 'absolute',
     top: 0,
     left: 0,
     right: 0,

--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -1,4 +1,4 @@
-import { getComments } from "@/lib/queries/comments";
+import { getComments } from "@/lib/firestore/comments";
 import { useQuery } from "@tanstack/react-query";
 
 export function useComments(postId: string | undefined) {

--- a/hooks/useCommunities.ts
+++ b/hooks/useCommunities.ts
@@ -1,7 +1,7 @@
 // hooks/useCommunities.ts — ✅ UPDATED (user-aware key)
 
 import { useAuth } from "@/hooks/useAuth";
-import { fetchMyCommunities, type Community } from "@/lib/queries/communities";
+import { fetchMyCommunities, type Community } from "@/lib/firestore/communities";
 import { useQuery } from "@tanstack/react-query";
 
 export function useCommunities() {

--- a/hooks/usePosts.ts
+++ b/hooks/usePosts.ts
@@ -18,7 +18,7 @@ import {
   type Post,
   type PostFilters,
   type UpdatePostData,
-} from "@/lib/queries/posts";
+} from "@/lib/firestore/posts";
 
 import {
   useInfiniteQuery,

--- a/hooks/useStories.ts
+++ b/hooks/useStories.ts
@@ -4,7 +4,7 @@ import {
     fetchStoryById,
     markStorySeen,
     type StoryRow,
-} from "@/lib/queries/stories";
+} from "@/lib/firestore/stories";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const storyKeys = {

--- a/lib/queryKeys/invalidateSocial.ts
+++ b/lib/queryKeys/invalidateSocial.ts
@@ -19,8 +19,8 @@ export function invalidateAfterBlock(
   qc.invalidateQueries({ queryKey: qk.notifications() });
 
   // Feeds / discovery
-  qc.invalidateQueries({ queryKey: qk.feed("home") });
-  qc.invalidateQueries({ queryKey: qk.feed("global") });
+  qc.invalidateQueries({ queryKey: qk.feed({ scope: "home" }) });
+  qc.invalidateQueries({ queryKey: qk.feed({ scope: "global" }) });
   qc.invalidateQueries({ queryKey: qk.explore() });
   qc.invalidateQueries({ queryKey: qk.stories() });
 
@@ -48,8 +48,8 @@ export function invalidateAfterUnfollow(
   qc.invalidateQueries({ queryKey: qk.userStats(myId) });
   qc.invalidateQueries({ queryKey: qk.notifications() });
 
-  qc.invalidateQueries({ queryKey: qk.feed("home") });
-  qc.invalidateQueries({ queryKey: qk.feed("following") });
+  qc.invalidateQueries({ queryKey: qk.feed({ scope: "home" }) });
+  qc.invalidateQueries({ queryKey: qk.feed({ scope: "following" }) });
 
   if (targetId) {
     qc.invalidateQueries({ queryKey: qk.followEdge(myId, targetId) });
@@ -74,7 +74,7 @@ export function invalidateAfterApproveDeny(
   qc.invalidateQueries({ queryKey: qk.userStats(myId) });
   qc.invalidateQueries({ queryKey: qk.notifications() });
 
-  qc.invalidateQueries({ queryKey: qk.feed("home") });
+  qc.invalidateQueries({ queryKey: qk.feed({ scope: "home" }) });
 
   if (followerId) {
     qc.invalidateQueries({ queryKey: qk.followEdge(followerId, myId) });


### PR DESCRIPTION
### Motivation
- Align app code with Firebase backend by removing leftover Supabase/legacy patterns and fixing TypeScript/runtime regressions introduced during migration.
- Stop referencing undefined/legacy variables that caused build failures and unpredictable runtime behavior in community creation and media/post flows.

### Description
- Fixed slug uniqueness logic in `ensureUniqueSlug` to use Firestore snapshot emptiness (`snapU.empty`) instead of legacy undefined variables. (`app/create/community.tsx`)
- Removed stale `uploadError` / `error` checks and Supabase-oriented comments so uploads now rely cleanly on Firebase Storage APIs and their error handling. (`app/create/post.tsx`, `app/create/media.tsx`, `app/create/poll.tsx`)
- Switched remaining imports from `@/lib/queries/*` to the Firebase-backed `@/lib/firestore/*` implementations for posts, communities, comments, and stories. (`hooks/*`, `app/create/story.tsx`)
- Corrected auth routing to use Firebase `user` shape, fixed linked-account email typing, refined tab badge logic, adjusted overlay positioning for React Native, and updated feed invalidation keys to call `qk.feed({ scope: ... })` for proper query-key typing. (`app/index.tsx`, `app/settings/linked-accounts.tsx`, `components/navigation/CurvedTabBar.tsx`, `components/post/ReactionButtons.tsx`, `lib/queryKeys/invalidateSocial.ts`)

### Testing
- Ran TypeScript type check with `npm run type-check` and it completed successfully (no errors). 
- Ran linter with `npm run lint` and it passed (only existing warnings remain). 
- Started the dev server with `npm run dev -- --port 8081` and verified the web bundle and initial UI by taking a screenshot for visual confirmation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1cfaeed0832db17aac256f5092d8)